### PR TITLE
Enhanced Babel configuration

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -18,7 +18,9 @@ var   ae =     null;
 /*******************************************************************/
 
 const BabelOptions = {
-	presets: ["es2015"]
+	presets: [require('babel-preset-es2015')],
+	plugins: [require('babel-plugin-transform-es3-member-expression-literals'), require('babel-plugin-transform-es3-property-literals'), require('babel-plugin-transform-es5-property-mutators')],
+	sourceRoot: __dirname
 }
 
 //These compression options are to satisfy After Effects old javascript engine.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
   "license": "ISC",
   "dependencies": {
     "babel-core": "^6.4.5",
+    "babel-plugin-transform-es3-member-expression-literals": "^6.8.0",
+    "babel-plugin-transform-es3-property-literals": "^6.8.0",
+    "babel-plugin-transform-es5-property-mutators": "^6.8.0",
     "babel-preset-es2015": "^6.3.13",
     "is-explicit": "^1.0.1",
     "jsesc": "^1.2.0",


### PR DESCRIPTION
* Add more transforms to increase ECMAScript compliance - still partial because of ExtendScript parser limitations.
* Require Babel preset and plugins explicitly (and set sourceRoot), to unbreak `npm link after-effects`.