### PR TITLE
Use exec/execSync's cwd option instead of shell cd command

### DIFF
--- a/lib/platform-win.js
+++ b/lib/platform-win.js
@@ -45,7 +45,7 @@ module.exports = {
     return create_jsx_script(command)
     //Execute JSX Script
     .then( jsx => new Promise((resolve,reject) => {
-      exec(`cd ${jsx.program_path} & afterfx.exe -r ${jsx.script}`, (err, stdout, stderr) => {
+      exec(`afterfx.exe -r ${jsx.script}`, {cwd: jsx.program_path}, (err, stdout, stderr) => {
         // see * below
         //if (err) return reject(err);
         //if (stderr) return reject(stderr);
@@ -61,7 +61,7 @@ module.exports = {
     let jsx = create_jsx_script(command, true);
     //Execute JSX
     try {
-      execSync(`cd ${jsx.program_path} & afterfx.exe -r ${jsx.script}`);
+      execSync(`afterfx.exe -r ${jsx.script}`, {cwd: jsx.program_path});
     } catch (err) {
       //TODO *
       //I don't know why, executing a child process always throws an error in


### PR DESCRIPTION
This fixes, among other things, the failure that arises when the current process and After Effects reside on different logical drives (e.g. `C:` and `E:`). That particular problem could also be fixed by using `cd /D`, but at this point it's much cleaner to use the dedicated option rather than a shell command.