### PR TITLE
Error: ENOTDIR: not a directory

### DIFF
--- a/lib/platform-mac.js
+++ b/lib/platform-mac.js
@@ -13,9 +13,17 @@ const exec =      child.exec,
       execSync =  child.execSync;
 
 let program = find_program('/Applications');
-while(!program.endsWith('.app')) {
-  program = find_program(program)
-}
+
+function find_app(program_dir) {
+  let files_in_program_dir = fs.readdirSync(program_dir);
+  for (var i = 0; i < files_in_program_dir.length; i++) {
+    let file = files_in_program_dir[i];
+    if (/^Adobe After Effects C(C|S).+.app$/.test(file))
+      return program_dir + "/" + file;
+  }
+  return null;
+};
+program = find_app(program);
 
 function check_for_missing_app_hack(error) {
   //this is a gross hack that will only exist temporarily. I haven't

--- a/lib/platform-mac.js
+++ b/lib/platform-mac.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const fs = 		       require('fs'),
+const fs =           require('fs'),
       child =        require('child_process'),
       path =         require('path'),
       uuid =         require('uuid'),


### PR DESCRIPTION
Hi,

I'm really surprised and happy to find after-effects npm module!
However this great module does not work with After Effects CC 2015, it seems installed components are different from previous ones.

I don't think this PR is excellent, but works enough for me, and this is just an information. not expect merging.

```
$ cat node_ae.js
var ae = require("after-effects");
```

`Adobe After Effects CC 2015.3 をアンインストール` looks like symlink for uninstalling After Effects.

```
$ node node_ae.js
fs.js:951
  return binding.readdir(pathModule._makeLong(path), options.encoding);
                 ^

Error: ENOTDIR: not a directory, scandir '/Applications/Adobe After Effects CC 2015.3/Adobe After Effects CC 2015.3 をアンインストール '
    at Error (native)
    at Object.fs.readdirSync (fs.js:951:18)
    at module.exports (/Users/shrkw/Documents/sample/prototype/node_modules/after-effects/lib/find-program.js:7:33)
    at Object.<anonymous> (/Users/shrkw/Documents/sample/prototype/node_modules/after-effects/lib/platform-mac.js:17:13)
    at Module._compile (module.js:541:32)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:458:32)
    at tryModuleLoad (module.js:417:12)
    at Function.Module._load (module.js:409:3)
    at Module.require (module.js:468:17)
```

```
 $ ls -l /Applications/Adobe\ After\ Effects\ CC\ 2015.3
total 240
-rw-r--r--@  1 root  admin      0  7 21 10:18 Adobe After Effects CC 2015.3 をアンインストール
drwxrwxr-x   3 root  admin    102  7 21 10:17 Adobe After Effects CC 2015.app
drwxrwxr-x   3 root  admin    102  7 21 10:17 Adobe After Effects Render Engine.app
-rw-r--r--@  1 root  admin      0  7 21 10:18 Icon
drwxrwxr-x   7 root  admin    238  7 21 10:17 Plug-ins
drwxrwxr-x  15 root  admin    510  7 21 10:17 Presets
drwxrwxr-x  19 root  admin    646  7 21 10:17 Scripts
-rwxrwxr-x   1 root  admin  52544  7 21 10:17 aerender
```
