### PR TITLE
+ typescript  index.d.ts, + ts-node

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,176 @@
+/// <reference types="types-for-adobe/AfterEffects/2018"  />
+ 
+ 
+type allTypes = CompItem|FootageItem|FolderItem|AVLayer| ShapeLayer| TextLayer| LightLayer| CameraLayer|Property|PropertyGroup;
+type allCollectionTypes = CompItem[]|FootageItem[]|FolderItem[]|AVLayer[]| ShapeLayer[]| TextLayer[]| LightLayer[]| CameraLayer[]|Property[]|PropertyGroup[];
+type layerTypes = AVLayer| ShapeLayer|TextLayer| LightLayer| CameraLayer
+type allSelectorTypes = string|RegExp | Function | Number
+type allContexts = ItemCollection|LayerCollection|Query|[]
+
+declare type ES3Object= Object 
+declare module aftereffects_custom  {
+
+    
+    interface options { 
+      /**
+       * @description If true, the code will be minified before being sent to After Effects. This is disabled by default, which is different from previous versions of this package. I feel there's little point in spending the extra time to minify code that isn't going over a network. Still, you can set minify to true if you're into that sort of thing.
+       */
+      multi : boolean , 
+      noui : boolean , 
+      minify? : boolean ,
+      /**
+       * @description By default, ae will look for an After Effects installation in your platforms default application directory. If you've installed it elsewhere, you'll have to set this to the custom app directory.
+       */ 
+      program : string 
+      /**
+       *  @description Includes is an array which will concatanate the code from other files into your command, for use inside After Effects
+       *  @default console.js Provides console.log to the After Effects namespace. 'console.log' inside After Effects will return logs to the node.js console when execution is complete, assuming you correctly have Preferences -> General -> Allow Scripts to Write Files and Access Network set inside After Effects.
+       *  @default es5-shim.js The javascript environment within After Effects is very dated, pre ES5. With es5-shim included, methods and functions available in es5 will be available.
+       * @default get.js Provides a jQuery inspired selector object to work with items in After Effects inside of an object called 'get' 
+       */
+      includes : string[  ]
+      /**
+       * @description  With errorHandling enabled, errors thrown in After Effects will be suppressed and returned in the promise result:
+         @description  With errorHandling disabled, After Effects will create a popup and prevent further code execution until it is dealt with
+       */ 
+     errorHandling : boolean 
+     testing : boolean 
+     commandSavePath : string
+    }
+    let   options:options
+   // function execute<T,R>( fn:(args:T) => void    ) :Promise<void>  
+    function executeSync<T>( fn:(args:T) => void   ) :void 
+    function execute<T,E>(fn:(param:T)=> E , param:T):Promise<E>  
+    function compile(fn :()=> any):string 
+    function create<T>(fn :()=> any , path : string):Promise<T>
+    function createSync(fn:()=> any,path:string) :void 
+    
+    class  Command  {
+
+      /**
+       * 
+       * @param name of the script  
+       */
+      constructor( fn:(name:string)=>void)
+ 
+    }
+
+    // get api 
+   
+    export function execute(fn:()=>void):void 
+
+}
+export declare class Query {
+    /**
+     * 
+     * @param callback apply function to iterate over query result  
+     * 
+     */
+    each<T extends allTypes>(callback:(item:T ,index:number)=>void):Query 
+    set<T>(prop:String , value : T ) : void 
+    /**
+     * 
+     * @param index get item from collection 
+     */
+    selection(index:number) :allTypes; 
+    children() : Query; 
+    /**
+     * 
+     * @param prop string  
+     */
+
+    get<T>(prop:string) : T;
+
+   
+    
+}
+ /**
+  * 
+  * @param value 
+  * @param checkCls  
+  */
+export declare function is(value : any , ...checkCls: any  ) : boolean
+/**
+ * general get module 
+ */
+export declare module  get { 
+    
+   
+   /**
+         * @description selects CompItem from a project 
+         * @param item
+         * @param context 
+         * @param selector 
+         * @returns Query 
+         */
+    function   comps(  selector?:allSelectorTypes):Query 
+        
+        /**
+         * 
+         * @param item 
+         * @param context 
+         * @param selector 
+         * @returns Query 
+         */
+      function   items( selector?:allSelectorTypes):Query 
+        /**
+         * 
+         * @param item 
+         * @param context 
+         * @param selector
+         * @returns Query  
+         */
+        function      sources( selector?:allSelectorTypes):Query 
+        /**
+         * 
+         * @param item 
+         * @param context 
+         * @param selector
+         * @returns Query  
+         */
+      function   folders(  selector?:allSelectorTypes):Query 
+        
+
+        /**
+         * 
+         * @param item 
+         * @param context 
+         * @param selector
+         * @returns Query  
+         */
+          function  footage( selector?:allSelectorTypes):Query 
+
+        /**
+         * 
+         * @param item 
+         * @param context 
+         * @param selector
+         * @return Query  
+         */
+       function   layers( context?:LayerCollection, selector?:allSelectorTypes):Query 
+        /**
+         * 
+         * @param item 
+         * @param context 
+         * @param selector
+         * returns Query  
+         */
+        function  props(  context?:AVLayer  | TextLayer  , selector?:allSelectorTypes):Query 
+       /**
+        * 
+        * @param selector 
+        * @returns Query 
+        */
+       function  root(selector?:allSelectorTypes):Query
+
+        
+}
+/**
+ * @returns all items in the project 
+ */
+export declare function get() :Query 
+
+ 
+
+
+ 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,11 @@
     "is-explicit": "^1.0.1",
     "jsesc": "^1.2.0",
     "uglify-js": "^2.6.2",
-    "uuid": "^2.0.1"
+    "uuid": "^2.0.1" , 
+    "ts-node": "^8.3.0",
+    "types-for-adobe": "^1.5.0",
+  } ,
+  "devDependencies" : {
+  	"typescript": "^3.6.2"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,62 @@
+{
+  "compilerOptions": {
+    /* Basic Options */
+    "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
+    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+     "lib": ["es2015"],                             /* Specify library files to be included in the compilation. */
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    // "outDir": "./",                        /* Redirect output structure to the directory. */
+    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "composite": true,                     /* Enable project compilation */
+    // "incremental": true,                   /* Enable incremental compilation */
+    // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true,                           /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
+    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+
+    /* Source Map Options */
+    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+  }
+}


### PR DESCRIPTION
Typescript definition file index.d.ts added.types-for-adobe package required for intellisense support. ts-node package added in order to remove reqirements for compiling.ts files to .js . script may run in commandline as  '$> ts-node {scriptfilename}.ts'